### PR TITLE
Bump io-streams upper bound

### DIFF
--- a/irc-dcc.cabal
+++ b/irc-dcc.cabal
@@ -31,7 +31,7 @@ library
                      , attoparsec      >= 0.13.0.1 && < 0.14
                      , binary          >= 0.7.5.0  && < 0.10
                      , bytestring      >= 0.10.6.0 && < 0.11
-                     , io-streams      >= 1.3.5.0  && < 1.5
+                     , io-streams      >= 1.3.5.0  && < 1.6
                      , iproute         >= 1.7.0    && < 1.8
                      , irc-ctcp        >= 0.1.3.0  && < 0.2
                      , mtl             >= 2.2.1    && < 2.3


### PR DESCRIPTION
Tests pass with the latest version (1.5.0.1).